### PR TITLE
Adding some seo friendly urls

### DIFF
--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardsController < ApplicationController
 
   def show
-    redirect_to themes_path unless current_user.admin?
+    redirect_to semantic_ui_themes_path unless current_user.admin?
 
     @themes = Theme.pending
   end

--- a/app/controllers/payment_preferences_controller.rb
+++ b/app/controllers/payment_preferences_controller.rb
@@ -7,10 +7,10 @@ class PaymentPreferencesController < ApplicationController
 
     if params[:type] == "card"
       current_user.stripe_account.update_from_card(token)
-      redirect_to themes_path
+      redirect_to semantic_ui_themes_path
     elsif params[:type] == "bank_account"
       current_user.stripe_account.update_from_bank_account(token)
-      redirect_to themes_path
+      redirect_to semantic_ui_themes_path
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
   def create
     if user = User.find_by_email(params[:email]).try(:authenticate, params[:password])
       session[:user_id] = user.id
-      redirect_to themes_path, :notice => t(:"sessions.successful_login")
+      redirect_to semantic_ui_themes_path, :notice => t(:"sessions.successful_login")
     else
       flash.now[:alert] = t(:"sessions.invalid_login")
       render :action => 'new'

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -42,7 +42,7 @@ class SnippetsController < ApplicationController
 
   def destroy
     @snippet.destroy
-    redirect_to snippets_path, notice: 'Deletion successful'
+    redirect_to semantic_ui_snippets_path, notice: 'Deletion successful'
   end
 
   private

--- a/app/models/snippet.rb
+++ b/app/models/snippet.rb
@@ -2,4 +2,8 @@ class Snippet < ActiveRecord::Base
   belongs_to :user, :foreign_key => "user_id"
 
   validates_presence_of :title, :html
+
+  def to_param
+    "#{id} #{title}".parameterize
+  end
 end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -58,4 +58,8 @@ class Theme < ActiveRecord::Base
       :statement_description => I18n.t(:"transfers.notice", theme_name: self.name)
     )
   end
+
+  def to_param
+    "#{id} #{name}".parameterize
+  end
 end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :categories do %>
   <div class="ui sub secondary pointing menu">
-    <%= nav_link "All", themes_path %>
+    <%= nav_link "All", semantic_ui_themes_path %>
     <% Category.order(:name).each do |category| %>
       <%= nav_link category.name, category_path(category) %>
     <% end %>

--- a/app/views/info/home.html.erb
+++ b/app/views/info/home.html.erb
@@ -2,7 +2,7 @@
   <div class="content">
     <h1>All Themes Semantic</h1>
     <p>Differentiate yourself and your design with a Semantic UI theme or template. Semantic UI is an easy to use front-end framework with its own style and purpose. Learn more <a href="http://www.semantic-ui.com">here.</a> </p>
-    <%#= link_to themes_path, class: "ui animated button green" do %>
+    <%#= link_to semantic_ui_themes_path, class: "ui animated button green" do %>
       <div class="visible content">View all Themes</div>
       <div class="hidden content">
         <i class="right arrow icon"></i>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
       <div class="three wide column">
         <h5 class="ui blue inverted header">Themes</h5>
         <div class="ui inverted link list">
-          <%= link_to "View all Themes", themes_path, class: "item" %>
+          <%= link_to "View all Themes", semantic_ui_themes_path, class: "item" %>
           <%= link_to "Sell a Theme", new_theme_path, class: "item" %>
           <%= link_to "How it Works", sell_path, class: "item" %>
         </div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -3,8 +3,8 @@
     <%= link_to root_path, :class => 'item' do %>
       <b>Semantic</b> Kit
     <% end %>
-    <%= link_to "Themes", themes_path, class: "item" %>
-    <%= link_to "Snippets", snippets_path, class: "item" %>
+    <%= link_to "Themes", semantic_ui_themes_path, class: "item" %>
+    <%= link_to "Snippets", semantic_ui_snippets_path, class: "item" %>
     <div class="ui dropdown item">
       <a href="#">Expo</a>
       <div class="menu">

--- a/app/views/snippets/show.html.erb
+++ b/app/views/snippets/show.html.erb
@@ -5,7 +5,7 @@
   <div class="ui breadcrumb">
     <%= link_to "Semantic Kit", root_path %>
     <i class="right chevron icon divider"></i>
-    <%= link_to "Snippets", snippets_path, class: "section" %>
+    <%= link_to "Snippets", semantic_ui_snippets_path, class: "section" %>
     <i class="right chevron icon divider"></i>
     <%= @snippet.title %>
   </div>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -15,7 +15,7 @@
 
 <% content_for :categories do %>
   <div class="ui sub secondary pointing menu">
-    <%= nav_link "All", themes_path %>
+    <%= nav_link "All", semantic_ui_themes_path %>
     <% Category.order(:name).each do |category| %>
       <%= nav_link category.name, category_path(category) %>
     <% end %>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% content_for :subtext do %>
   <div class="ui breadcrumb">
-    <%= link_to "Themes", themes_path, class: "section" %>
+    <%= link_to "Themes", semantic_ui_themes_path, class: "section" %>
     <i class="right chevron icon divider" style="color: #fff;"></i>
     <% if @theme.categories.first %>
       <%= link_to @theme.categories.first.name, category_path(@theme.categories.first) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,11 @@ WrapSemantic::Application.routes.draw do
   get "/logout", to: "sessions#destroy", as: "logout"
   get "/signin", to: "sessions#new",     as: "signin"
 
+  ["semantic-ui-themes", "semantic-ui-snippets"].each do |slug|
+    controller = slug.gsub("semantic-ui-", "")
+    get "/#{slug}", to: "#{controller}#index"
+  end
+
   resource  :account,             only: [:show]
   resources :categories
   resource  :dashboard,           only: [:show]


### PR DESCRIPTION
Does two things:
- Adds `semantic-ui-themes` and `semantic-ui-snippets` to the URLs
- Overrides `to_param` in `Theme` and `Snippet` so their URLs now include more about them. Examples:
  - Theme: `/semantic-ui-themes/1-theme-name`
  - Snippet: `/semantic-ui-snippest/1-snippet-title`

Should close #60 @wallawe 
