### PR TITLE
Add ability to submit a site

### DIFF
--- a/app/controllers/expos_controller.rb
+++ b/app/controllers/expos_controller.rb
@@ -1,0 +1,27 @@
+class ExposController < ApplicationController
+  before_filter :authenticate, only: [:new, :create]
+
+  def new
+    @expo = Expo.new
+  end
+
+  def create
+    expo = Expo.create(expo_params)
+    if expo
+      expo.assign_image!
+      redirect_to expos_path, notice: "Your site #{expo.url} is in!"
+    else
+      redirect_to new_expo_path
+    end
+  end
+
+  def index
+    @expos = Expo.with_image.paginate(page: params[:page], per_page: 20).order('created_at DESC')
+  end
+
+  private
+
+    def expo_params
+      params.require(:expo).permit(:url)
+    end
+end

--- a/app/models/expo.rb
+++ b/app/models/expo.rb
@@ -1,0 +1,21 @@
+require 'screencap'
+
+class Expo < ActiveRecord::Base
+  validates :url, presence: true
+
+  mount_uploader :image, ImageUploader
+
+  scope :with_image, -> { where("image IS NOT NULL") }
+
+  def assign_image!
+    fetcher       = ::Screencap::Fetcher.new(self.url)
+    random_string = SecureRandom.urlsafe_base64(nil, false)
+
+    screenshot = fetcher.fetch(
+      :output => "tmp/images/#{self.url}_#{random_string}.png"
+    )
+
+    self.image = screenshot
+    self.save!
+  end
+end

--- a/app/views/expos/_expo.html.erb
+++ b/app/views/expos/_expo.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag expo.image_url %>

--- a/app/views/expos/index.html.erb
+++ b/app/views/expos/index.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  View our Expo
+<% end %>
+<% content_for :subtext do %>
+<% end %>
+
+<%= render @expos %>

--- a/app/views/expos/new.html.erb
+++ b/app/views/expos/new.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title do %>
+  Add your site
+<% end %>
+<% content_for :subtext do %>
+<% end %>
+
+<%= form_for @expo do |f| %>
+
+  <% if @expo.errors.any? %>
+    <div class="ui red message">
+      <div class="header">We noticed some issues</div>
+      <ul class="list">
+        <% @expo.errors.full_messages.each do |message| %>
+          <li id="error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= hidden_field_tag(:user_id, current_user.id) %>
+
+  <div class="ui form">
+    <div class="field">
+      <%= f.label :url, "Site URL" %>
+      <%= f.url_field :url, placeholder: "ex: http://google.com" %>
+    </div>
+  <div class="ui form">
+    <%= f.submit "Submit", :class => "ui button green" %>
+    <%= link_to "Cancel", :back %>
+  </div>
+<% end %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -8,8 +8,8 @@
     <div class="ui dropdown item">
       <a href="#">Expo</a>
       <div class="menu">
-        <a href="#" class="item">View Gallery</a>
-        <a href="#" class="item">Submit a Site</a>
+        <%= link_to "View Gallery", expos_path, class: "item" %>
+        <%= link_to "Submit a Site", new_expo_path, class: "item" %>
       </div>
     </div>
     <div class="right menu">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ WrapSemantic::Application.routes.draw do
   resource  :account,             only: [:show]
   resources :categories
   resource  :dashboard,           only: [:show]
+  resources :expos,               only: [:new, :create, :index]
 
   resources :favorites,           only: [:create, :destroy]
 

--- a/db/migrate/20141202123917_create_expos.rb
+++ b/db/migrate/20141202123917_create_expos.rb
@@ -1,0 +1,10 @@
+class CreateExpos < ActiveRecord::Migration
+  def change
+    create_table :expos do |t|
+      t.references :user
+      t.string :url
+      t.string :image
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141126212531) do
+ActiveRecord::Schema.define(version: 20141202123917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,14 @@ ActiveRecord::Schema.define(version: 20141126212531) do
   create_table "categories", force: true do |t|
     t.string   "name"
     t.string   "slug"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "expos", force: true do |t|
+    t.integer  "user_id"
+    t.string   "url"
+    t.string   "image"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
@wallawe Here we go. So this is a bit cludgy in the UX right now. You submit a site and we use the `screencap` gem to fetch the image then store the File in `tmp` and upload it to S3. We can add height/width options on `screencap` so the image sizes are consistent so let's chat about that. Of course we could also scrap this and use something like embedly or some other service.
