### PR TITLE
Fix validation error during download on subscription_id

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -3,7 +3,8 @@ class DownloadsController < ApplicationController
     theme = Theme.find_by_id(params[:theme_id])
 
     if theme && current_user && current_user.can_download?(theme)
-      current_user.downloads.create!(theme_id: theme.id)
+      valid_subscription = current_user.subscription_with_remaining_downloads_for(theme)
+      current_user.downloads.create!(theme_id: theme.id, subscription_id: valid_subscription.id)
       redirect_to theme.file_package.url
     elsif theme && params[:token]
       guest_subscription = GuestSubscription.where(theme_id: theme.id, token: params[:token]).first

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,11 @@ class User < ActiveRecord::Base
   end
 
   def subscribed?(theme)
-    !!subscriptions_for(theme).detect {|s| s.has_remaining_downloads?(theme) }
+    !!subscription_with_remaining_downloads_for(theme)
+  end
+
+  def subscription_with_remaining_downloads_for(theme)
+    subscriptions_for(theme).detect {|s| s.has_remaining_downloads?(theme) }
   end
 
   def subscriptions_for(theme)


### PR DESCRIPTION
Currently if you try to download a theme there's an error when creating the download object because we validate the presence of `subscription_id` for the download. 

Since I needed to remind myself of the data models, I'll remind myself here too: Subscription is what we create when a User purchases a theme, while Download lives on Subscription as a way of keeping a tally of the number of times a person can download a theme after they bought it. In order to do that accurately a Download needs a `subscription_id`, which is why we validate the presence of `subscription_id` when we create a download. We got an error because the download didn't have a `subscription_id` on it. In fact I don't think it ever would have.

This shifts around some logic to:
- Check if the current user can download the theme, which returns a boolean of whether the user has a subscription that has remaining downloads
- If the above check happens, we assume that subscription exists, so we pass its id to the download as the `subscription_id`

You may be wondering why we never got this error, as am I. Well we've only had one purchase and it was a Guest purchase. After looking at how we handle guest stuff, [that code](https://github.com/wallawe/semantic-kit/blob/master/app/controllers/downloads_controller.rb#L11) is set up to create a guest download based off of the guest subscriptions. So each guest download has a `subscription_id`, passing the validation there.
