### PR TITLE
Fix bug where someone is logged in and made a guest purchase

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -70,7 +70,9 @@ class ThemesController < ApplicationController
 
     def should_see_download_notice?
       return if !params[:purchase_mailer]
-      if current_user
+      # Sometimes people are logged in AND somehow getting to the theme with a token
+      # this forces the lookup on GuestSubscription if params[:token] exists
+      if current_user && !params[:token]
         current_user.can_download?(@theme) || current_user.owns_theme?(@theme)
       elsif GuestSubscription.exists_and_downloadable?(params[:id], params[:token])
         true

--- a/app/helpers/themes_helper.rb
+++ b/app/helpers/themes_helper.rb
@@ -13,7 +13,9 @@ module ThemesHelper
   end
 
   def call_to_action(theme)
-    if current_user
+    # Sometimes people are logged in AND somehow getting to the theme with a token
+    # this forces the lookup on GuestSubscription if params[:token] exists
+    if current_user && !params[:token]
       if current_user.admin? && !theme.approved?
         render "approve_button"
       elsif current_user.can_download?(theme) || current_user.owns_theme?(theme)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,11 @@ travis = User.create(email: "travis@test.com", password: "password",
                      location: "Washington, DC",
                      website: "tcvalentine.com", about: "Ginger")
 
+test = User.create(email: "help@semantickit.com", password: "helptest",
+                     password_confirmation: "helptest", username: "semantictest",
+                     location: "Washington, DC",
+                     website: "semantickit.com", about: "Testing")
+
 #####################
 ### Create Categories
 #####################


### PR DESCRIPTION
We got a screenshot the last time someone had an issue purchasing. Turns out they were logged in despite making a guest purchase (which I'm not sure I understand why but alas). The screenshot showed them logged in AND having a token param from the mailer. Those are only sent when a guest purchase is made. Guest Purchases are only made when someone is logged out...I think. Anyway, I created a test account in the db, logged in, and pasted the link from the screenshot:

http://www.semantickit.com/themes/9-minimal-landing-page-theme?purchase_mailer=true&token=nt6ZVvP4Y5rgMGX11-m4ew

I see the same as what's in the screenshot:

![unnamed](https://cloud.githubusercontent.com/assets/1275771/14661958/fe586a62-067f-11e6-92f8-c80e926f8a60.png)

This should fix that...
